### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -24,7 +24,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/audit-check@v1
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions-rs/audit-check@35b7b53b1e25b55642157ac01b4adceb5b9ebef3 # v1.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-test-grpc.yml
+++ b/.github/workflows/build-and-test-grpc.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Build Docker image
       uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,7 +42,7 @@ jobs:
     outputs:
       core-modified: ${{ steps.change-detection.outputs.core-modified }} # map step output to job output
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
       - name: Run change detection
@@ -80,7 +80,7 @@ jobs:
       RUSTC_WRAPPER: sccache
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Ensure, OpenSSL is available in Windows
         if: matrix.os == 'windows-latest'
@@ -167,7 +167,7 @@ jobs:
     needs: check-for-run-condition
     if: ${{ needs.check-for-run-condition.outputs.should-run == 'true' }}
     # owner/repository of workflow has to be static, see https://github.community/t/env-variables-in-uses/17466
-    uses: iotaledger/identity.rs/.github/workflows/shared-build-wasm.yml@main
+    uses: iotaledger/identity.rs/.github/workflows/shared-build-wasm.yml@865f92b359b1bb92d8f4a8d638b0b5d60eefb80a # main
     with:
       output-artifact-name: identity-wasm-bindings-build
 
@@ -183,10 +183,10 @@ jobs:
           - os: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1.4.6
         with:
           node-version: 16.x
 
@@ -195,7 +195,7 @@ jobs:
         working-directory: bindings/wasm
 
       - name: Download bindings/wasm artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: identity-wasm-bindings-build
           path: bindings/wasm
@@ -223,10 +223,10 @@ jobs:
           - os: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1.4.6
         with:
           node-version: 16.x
   
@@ -235,7 +235,7 @@ jobs:
         working-directory: bindings/wasm
 
       - name: Download bindings/wasm artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: identity-wasm-bindings-build
           path: bindings/wasm
@@ -244,7 +244,7 @@ jobs:
         uses: './.github/actions/iota-sandbox/setup'
 
       - name: Build Docker image
-        uses: docker/build-push-action@v6.2.0
+        uses: docker/build-push-action@15560696de535e4014efeff63c48f16952e52dd1 # v6.2.0
         with:
           context: bindings/wasm/
           file: bindings/wasm/cypress/Dockerfile
@@ -271,10 +271,10 @@ jobs:
           - os: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1.4.6
         with:
           node-version: 16.x
 
@@ -283,7 +283,7 @@ jobs:
         working-directory: bindings/wasm
 
       - name: Download bindings/wasm artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           name: identity-wasm-bindings-build
           path: bindings/wasm
@@ -292,7 +292,7 @@ jobs:
         uses: './.github/actions/iota-sandbox/setup'
 
       - name: Build Docker image
-        uses: docker/build-push-action@v6.2.0
+        uses: docker/build-push-action@15560696de535e4014efeff63c48f16952e52dd1 # v6.2.0
         with:
           context: bindings/wasm/
           file: bindings/wasm/cypress/Dockerfile

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Setup Rust
         uses: './.github/actions/rust/rust-setup'

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       # we use nightly to get access to advanced format capabilities
       - name: Setup Rust

--- a/.github/workflows/grpc-publish-to-dockerhub.yml
+++ b/.github/workflows/grpc-publish-to-dockerhub.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         ref: ${{ github.event.inputs.branch }}
 

--- a/.github/workflows/rust-automatic-release-and-publish.yml
+++ b/.github/workflows/rust-automatic-release-and-publish.yml
@@ -11,7 +11,7 @@ jobs:
   call-create-release-workflow:
     if: github.event.pull_request.merged == true
     # owner/repository of workflow has to be static, see https://github.community/t/env-variables-in-uses/17466
-    uses: iotaledger/identity.rs/.github/workflows/shared-release.yml@main
+    uses: iotaledger/identity.rs/.github/workflows/shared-release.yml@865f92b359b1bb92d8f4a8d638b0b5d60eefb80a # main
     with:
       changelog-config-path: ./.github/.github_changelog_generator
       pre-release-tag-regex: ^v[0-9]+\.[0-9]+\.[0-9]+-(?<pre_release>\w+)\.\d+$
@@ -26,7 +26,7 @@ jobs:
     if: ${{ needs.call-create-release-workflow.outputs.is-release }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Dummy Publish to crates.io
         # TODO: implement proper publish
         run: echo beep boop, pretending to publish

--- a/.github/workflows/rust-create-hotfix-pr.yml
+++ b/.github/workflows/rust-create-hotfix-pr.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   create-hotfix-pr:
     # owner/repository of workflow has to be static, see https://github.community/t/env-variables-in-uses/17466
-    uses: iotaledger/identity.rs/.github/workflows/shared-create-hotfix-pr.yml@main
+    uses: iotaledger/identity.rs/.github/workflows/shared-create-hotfix-pr.yml@865f92b359b1bb92d8f4a8d638b0b5d60eefb80a # main
     with:
       branch: ${{ github.event.inputs.branch }}
       branch-regex: ^support\/v[0-9]+\.[0-9]+$

--- a/.github/workflows/rust-create-release-pr.yml
+++ b/.github/workflows/rust-create-release-pr.yml
@@ -21,7 +21,7 @@ jobs:
   create-dev-release-pr:
     if: github.event.inputs.release-type != 'main'
     # owner/repository of workflow has to be static, see https://github.community/t/env-variables-in-uses/17466
-    uses: iotaledger/identity.rs/.github/workflows/shared-create-dev-release-pr.yml@main
+    uses: iotaledger/identity.rs/.github/workflows/shared-create-dev-release-pr.yml@865f92b359b1bb92d8f4a8d638b0b5d60eefb80a # main
     with:
       tag-prefix: v
       tag-postfix: -${{ github.event.inputs.release-type }}.
@@ -35,7 +35,7 @@ jobs:
   create-main-release-pr:
     if: github.event.inputs.release-type == 'main'
     # owner/repository of workflow has to be static, see https://github.community/t/env-variables-in-uses/17466
-    uses: iotaledger/identity.rs/.github/workflows/shared-create-main-release-pr.yml@main
+    uses: iotaledger/identity.rs/.github/workflows/shared-create-main-release-pr.yml@865f92b359b1bb92d8f4a8d638b0b5d60eefb80a # main
     with:
       tag-prefix: v
       tag-base: ${{ github.event.inputs.version }}

--- a/.github/workflows/rust-publish-to-crates.yml
+++ b/.github/workflows/rust-publish-to-crates.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           ref: ${{ github.event.inputs.branch }}
       - name: Publish to crates.io

--- a/.github/workflows/shared-build-wasm.yml
+++ b/.github/workflows/shared-build-wasm.yml
@@ -38,7 +38,7 @@ jobs:
       RUSTC_WRAPPER: sccache
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           ref: ${{ inputs.ref }}
       - name: Setup Rust and cache
@@ -62,7 +62,7 @@ jobs:
           os: ${{matrix.os}}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1.4.6
         with:
           node-version: 16.x
 
@@ -82,7 +82,7 @@ jobs:
           os: ${{matrix.os}}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         with:
           name: ${{ inputs.output-artifact-name }}
           path: |

--- a/.github/workflows/shared-create-dev-release-pr.yml
+++ b/.github/workflows/shared-create-dev-release-pr.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           # Number of commits to fetch. 0 indicates all history for all branches and tags.
           fetch-depth: 0

--- a/.github/workflows/shared-create-hotfix-pr.yml
+++ b/.github/workflows/shared-create-hotfix-pr.yml
@@ -61,7 +61,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           # Number of commits to fetch. 0 indicates all history for all branches and tags.
           fetch-depth: 0

--- a/.github/workflows/shared-create-main-release-pr.yml
+++ b/.github/workflows/shared-create-main-release-pr.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           # Number of commits to fetch. 0 indicates all history for all branches and tags.
           fetch-depth: 0

--- a/.github/workflows/shared-release.yml
+++ b/.github/workflows/shared-release.yml
@@ -62,7 +62,7 @@ jobs:
       current-version: ${{ steps.determine-version.outputs.current-version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           # Number of commits to fetch. 0 indicates all history for all branches and tags.
           fetch-depth: 0

--- a/.github/workflows/wasm-automatic-release-and-publish.yml
+++ b/.github/workflows/wasm-automatic-release-and-publish.yml
@@ -12,7 +12,7 @@ jobs:
   call-create-release-workflow:
     if: github.event.pull_request.merged == true
     # owner/repository of workflow has to be static, see https://github.community/t/env-variables-in-uses/17466
-    uses: iotaledger/identity.rs/.github/workflows/shared-release.yml@main
+    uses: iotaledger/identity.rs/.github/workflows/shared-release.yml@865f92b359b1bb92d8f4a8d638b0b5d60eefb80a # main
     with:
       changelog-config-path: ./bindings/wasm/.github_changelog_generator
       pre-release-tag-regex: ^wasm-v[0-9]+\.[0-9]+\.[0-9]+-(?<pre_release>\w+)\.\d+$
@@ -26,7 +26,7 @@ jobs:
     needs: call-create-release-workflow
     if: ${{ needs.call-create-release-workflow.outputs.is-release }}
     # owner/repository of workflow has to be static, see https://github.community/t/env-variables-in-uses/17466
-    uses: iotaledger/identity.rs/.github/workflows/shared-build-wasm.yml@main
+    uses: iotaledger/identity.rs/.github/workflows/shared-build-wasm.yml@865f92b359b1bb92d8f4a8d638b0b5d60eefb80a # main
     with:
       output-artifact-name: identity-wasm-bindings-build
 
@@ -36,7 +36,7 @@ jobs:
     needs: [call-create-release-workflow, build-wasm]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Release to npm
         uses: './.github/actions/publish/publish-wasm'
         with:

--- a/.github/workflows/wasm-create-hotfix-pr.yml
+++ b/.github/workflows/wasm-create-hotfix-pr.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   create-hotfix-pr:
     # owner/repository of workflow has to be static, see https://github.community/t/env-variables-in-uses/17466
-    uses: iotaledger/identity.rs/.github/workflows/shared-create-hotfix-pr.yml@main
+    uses: iotaledger/identity.rs/.github/workflows/shared-create-hotfix-pr.yml@865f92b359b1bb92d8f4a8d638b0b5d60eefb80a # main
     with:
       branch: ${{ github.event.inputs.branch }}
       branch-regex: ^support\/wasm-v[0-9]+\.[0-9]+$

--- a/.github/workflows/wasm-create-release-pr.yml
+++ b/.github/workflows/wasm-create-release-pr.yml
@@ -21,7 +21,7 @@ jobs:
   create-dev-release-pr:
     if: github.event.inputs.release-type != 'main'
     # owner/repository of workflow has to be static, see https://github.community/t/env-variables-in-uses/17466
-    uses: iotaledger/identity.rs/.github/workflows/shared-create-dev-release-pr.yml@main
+    uses: iotaledger/identity.rs/.github/workflows/shared-create-dev-release-pr.yml@865f92b359b1bb92d8f4a8d638b0b5d60eefb80a # main
     with:
       tag-prefix: wasm-v
       tag-postfix: -${{ github.event.inputs.release-type }}.
@@ -38,7 +38,7 @@ jobs:
   create-main-release-pr:
     if: github.event.inputs.release-type == 'main'
     # owner/repository of workflow has to be static, see https://github.community/t/env-variables-in-uses/17466
-    uses: iotaledger/identity.rs/.github/workflows/shared-create-main-release-pr.yml@main
+    uses: iotaledger/identity.rs/.github/workflows/shared-create-main-release-pr.yml@865f92b359b1bb92d8f4a8d638b0b5d60eefb80a # main
     with:
       tag-prefix: wasm-v
       tag-base: ${{ github.event.inputs.version }}

--- a/.github/workflows/wasm-publish-to-npm.yml
+++ b/.github/workflows/wasm-publish-to-npm.yml
@@ -19,7 +19,7 @@ jobs:
 
   build-wasm: 
     # owner/repository of workflow has to be static, see https://github.community/t/env-variables-in-uses/17466
-    uses: iotaledger/identity.rs/.github/workflows/shared-build-wasm.yml@main
+    uses: iotaledger/identity.rs/.github/workflows/shared-build-wasm.yml@865f92b359b1bb92d8f4a8d638b0b5d60eefb80a # main
     with:
       ref: ${{ github.event.inputs.branch }}
       output-artifact-name: identity-wasm-bindings-build
@@ -29,7 +29,7 @@ jobs:
     needs: [build-wasm]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           ref: ${{ github.event.inputs.branch }}
       - name: Release to npm


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v3` -> `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0`
  - Version: v3.6.0 | Latest: v6.0.2 | Release age: 90d
  - Commit: https://github.com/actions/checkout/commit/f43a0e5ff2bd294095638e18286ca9a3d1956744

- `actions-rs/audit-check@v1` -> `actions-rs/audit-check@35b7b53b1e25b55642157ac01b4adceb5b9ebef3 # v1.2.0`
  - Version: v1.2.0 | Latest: v1.2.0 | Release age: 2163d
  - Commit: https://github.com/actions-rs/audit-check/commit/35b7b53b1e25b55642157ac01b4adceb5b9ebef3

- `actions/checkout@v4` -> `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
  - Version: v4.3.1 | Latest: v6.0.2 | Release age: 90d
  - Commit: https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5

- `iotaledger/identity.rs/.github/workflows/shared-build-wasm.yml@main` -> `iotaledger/identity.rs/.github/workflows/shared-build-wasm.yml@865f92b359b1bb92d8f4a8d638b0b5d60eefb80a # main`
  - Version: main | Latest: v1.9.4-beta.1 | Release age: 10d
  - Commit: https://github.com/iotaledger/identity.rs/commit/865f92b359b1bb92d8f4a8d638b0b5d60eefb80a

- `actions/setup-node@v1` -> `actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1.4.6`
  - Version: v1.4.6 | Latest: v6.3.0 | Release age: 37d
  - Commit: https://github.com/actions/setup-node/commit/f1f314fca9dfce2769ece7d933488f076716723e

- `actions/download-artifact@v2` -> `actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1`
  - Version: v2.1.1 | Latest: v3.1.0-node20 | Release age: 23d
  - Commit: https://github.com/actions/download-artifact/commit/cbed621e49e4c01b044d60f6c80ea4ed6328b281
  - Warnings: 1 security advisory(ies) found, Action has 1 known advisory(ies)

- `docker/build-push-action@v6.2.0` -> `docker/build-push-action@15560696de535e4014efeff63c48f16952e52dd1 # v6.2.0`
  - Version: v6.2.0 | Latest: v7.0.0 | Release age: 35d
  - Commit: https://github.com/docker/build-push-action/commit/15560696de535e4014efeff63c48f16952e52dd1

- `iotaledger/identity.rs/.github/workflows/shared-release.yml@main` -> `iotaledger/identity.rs/.github/workflows/shared-release.yml@865f92b359b1bb92d8f4a8d638b0b5d60eefb80a # main`
  - Version: main | Latest: v1.9.4-beta.1 | Release age: 10d
  - Commit: https://github.com/iotaledger/identity.rs/commit/865f92b359b1bb92d8f4a8d638b0b5d60eefb80a

- `iotaledger/identity.rs/.github/workflows/shared-create-hotfix-pr.yml@main` -> `iotaledger/identity.rs/.github/workflows/shared-create-hotfix-pr.yml@865f92b359b1bb92d8f4a8d638b0b5d60eefb80a # main`
  - Version: main | Latest: v1.9.4-beta.1 | Release age: 10d
  - Commit: https://github.com/iotaledger/identity.rs/commit/865f92b359b1bb92d8f4a8d638b0b5d60eefb80a

- `iotaledger/identity.rs/.github/workflows/shared-create-dev-release-pr.yml@main` -> `iotaledger/identity.rs/.github/workflows/shared-create-dev-release-pr.yml@865f92b359b1bb92d8f4a8d638b0b5d60eefb80a # main`
  - Version: main | Latest: v1.9.4-beta.1 | Release age: 10d
  - Commit: https://github.com/iotaledger/identity.rs/commit/865f92b359b1bb92d8f4a8d638b0b5d60eefb80a

- `iotaledger/identity.rs/.github/workflows/shared-create-main-release-pr.yml@main` -> `iotaledger/identity.rs/.github/workflows/shared-create-main-release-pr.yml@865f92b359b1bb92d8f4a8d638b0b5d60eefb80a # main`
  - Version: main | Latest: v1.9.4-beta.1 | Release age: 10d
  - Commit: https://github.com/iotaledger/identity.rs/commit/865f92b359b1bb92d8f4a8d638b0b5d60eefb80a

- `actions/upload-artifact@v2` -> `actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1`
  - Version: v2.3.1 | Latest: v3.2.2 | Release age: 23d
  - Commit: https://github.com/actions/upload-artifact/commit/82c141cc518b40d92cc801eee768e7aafc9c2fa2


### Files modified

- `.github/workflows/audit.yml`
- `.github/workflows/build-and-test-grpc.yml`
- `.github/workflows/build-and-test.yml`
- `.github/workflows/clippy.yml`
- `.github/workflows/format.yml`
- `.github/workflows/grpc-publish-to-dockerhub.yml`
- `.github/workflows/rust-automatic-release-and-publish.yml`
- `.github/workflows/rust-create-hotfix-pr.yml`
- `.github/workflows/rust-create-release-pr.yml`
- `.github/workflows/rust-publish-to-crates.yml`
- `.github/workflows/shared-build-wasm.yml`
- `.github/workflows/shared-create-dev-release-pr.yml`
- `.github/workflows/shared-create-hotfix-pr.yml`
- `.github/workflows/shared-create-main-release-pr.yml`
- `.github/workflows/shared-release.yml`
- `.github/workflows/wasm-automatic-release-and-publish.yml`
- `.github/workflows/wasm-create-hotfix-pr.yml`
- `.github/workflows/wasm-create-release-pr.yml`
- `.github/workflows/wasm-publish-to-npm.yml`

### Security warnings

- 1 security advisory(ies) found
- Action has 1 known advisory(ies)